### PR TITLE
Fix dependency org.apache.beam » beam-it-neo4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
             <version>${dataflow-template.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.cloud.teleport</groupId>
-            <artifactId>it-neo4j</artifactId>
-            <version>${dataflow-template.version}</version>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-it-neo4j</artifactId>
+            <version>2.54.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The dependency `com.google.cloud.teleport:it-neo4j` doesn't seem to exist, and compilation as of now fails with the following:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.771 s
[INFO] Finished at: 2024-03-08T07:27:38+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project local-runner: Could not resolve dependencies for project org.neo4j.dataflow:local-runner:jar:1.0-SNAPSHOT: Could not find artifact com.google.cloud.teleport:it-neo4j:jar:1.0-SNAPSHOT -> [Help 1]
```

This PR attaches what I think is the right dependency. Compilation succeeds, at least. 